### PR TITLE
Cleanup cognito users before robot tests in CI

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,0 +1,25 @@
+name: Lint & test
+
+on: [push]
+
+jobs:
+  local_lint_test:
+    runs-on: ubuntu-latest
+    environment: local
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install
+        run: yarn
+
+      - name: Run lint
+        run: yarn workspace mobile-server lint
+
+      - name: Run tests
+        run: yarn workspace mobile-server test

--- a/.github/workflows/robot-test-local.yml
+++ b/.github/workflows/robot-test-local.yml
@@ -5,6 +5,9 @@ on: [push]
 jobs:
   local_robot_tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment: local
     steps:
       - name: Checkout code
@@ -49,6 +52,17 @@ jobs:
       - name: Wait for the server to be ready
         run: |
           timeout 60 sh -c "until curl --silent --fail http://localhost:5173; do echo 'Waiting for server...'; sleep 2; done"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_COGNITO_CLEANUP_ASSUME_ROLE }}
+          aws-region: ${{ vars.VITE_AWS_REGION }}
+
+      - name: Run Cognito cleanup
+        env:
+          USER_POOL_ID: ${{ vars.VITE_AWS_COGNITO_USER_POOL_ID }}
+        run: ./scripts/cleanup-cognito-users.sh
 
       - name: Run Robot Framework tests
         env:

--- a/apps/mobile-server/src/middleware/cognito-auth.middleware.spec.ts
+++ b/apps/mobile-server/src/middleware/cognito-auth.middleware.spec.ts
@@ -11,6 +11,9 @@ describe('CognitoAuthMiddleware', () => {
     mockAuthService = {
       verifyToken: jest.fn(),
       getCredentials: jest.fn(),
+      decodeToken: jest
+        .fn()
+        .mockReturnValue({ payload: { email: 'mockEmail' } }),
     };
 
     // Initialize the middleware with the mock authService
@@ -55,7 +58,8 @@ describe('CognitoAuthMiddleware', () => {
 
     expect(req.session).toEqual({
       userId: 'mockSub',
-      email: 'mockUsername',
+      email: 'mockEmail',
+      username: 'mockUsername',
       accessToken: 'mockAccessToken',
       identityToken: 'mockIdentityToken',
       awsCredentials: JSON.stringify({

--- a/apps/mobile-server/src/rooms/rooms.controller.spec.ts
+++ b/apps/mobile-server/src/rooms/rooms.controller.spec.ts
@@ -43,13 +43,16 @@ describe('RoomsController', () => {
       accessToken: 'test-access-token',
     };
 
-    const result = await roomsController.getRoomDiograph(mockSession);
+    const result = await roomsController.getRoomDiograph(mockSession, 'native');
 
     expect(result).toEqual('mock-diograph-data');
     expect(constructAndLoadRoom).toHaveBeenCalledWith(
       expect.stringContaining('s3://'),
       'S3Client',
       {
+        LocalClient: {
+          clientConstructor: expect.anything(),
+        },
         S3Client: {
           clientConstructor: expect.anything(),
           credentials: {


### PR DESCRIPTION
 Link Github & AWS together and assume specific CI-IAM-role from AWS
