### PR TITLE
Heroku CI deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy and robot tests
+name: Deploy and robot tests in production
 
 on:
   workflow_dispatch:
@@ -47,7 +47,7 @@ jobs:
         env:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
-          heroku git:remote -a ${{ secrets.HEROKU_APP_NAME }}
+          git remote add heroku https://heroku:${{ secrets.HEROKU_API_KEY }}@git.heroku.com/${{ secrets.HEROKU_APP_NAME }}.git
           git subtree push --prefix apps/mobile-server heroku main
 
       - name: Set up Python

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,15 @@ jobs:
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
           git remote add heroku https://heroku:${{ secrets.HEROKU_API_KEY }}@git.heroku.com/${{ secrets.HEROKU_APP_NAME }}.git
-          git subtree push --prefix apps/mobile-server heroku main
+          git subtree split --prefix apps/mobile-server -b heroku-deploy
+          git checkout heroku-deploy
+          git push heroku heroku-deploy:main --force
+          git checkout -- .
+          git checkout main
+
+          # Should work like this simple:
+          # git remote add heroku https://heroku:${{ secrets.HEROKU_API_KEY }}@git.heroku.com/${{ secrets.HEROKU_APP_NAME }}.git
+          # git subtree push --prefix apps/mobile-server heroku main
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,12 @@ jobs:
         run: echo $(robot --version)
 
       - name: Wait for deploy to be applied
-        run: sleep 5
+        run: sleep 3
+
+      - name: Run Cognito cleanup
+        env:
+          USER_POOL_ID: ${{ vars.VITE_AWS_COGNITO_USER_POOL_ID }}
+        run: ./scripts/cleanup-cognito-users.sh
 
       - name: Run Robot Framework tests
         env:
@@ -69,6 +74,11 @@ jobs:
           NON_CONFIRMED_EMAIL: ${{ vars.NON_CONFIRMED_EMAIL}}
           EXISTING_EMAIL: ${{ vars.EXISTING_EMAIL }}
         run: robot tests/main.robot
+
+      - name: Run Cognito cleanup
+        env:
+          USER_POOL_ID: ${{ vars.VITE_AWS_COGNITO_USER_POOL_ID }}
+        run: ./scripts/cleanup-cognito-users.sh
 
       - name: Upload test artifacts
         if: always()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,7 +52,7 @@ jobs:
           git checkout heroku-deploy
           git push heroku heroku-deploy:main --force
           git checkout -- .
-          git checkout main
+          git checkout -
 
           # Should work like this simple:
           # git remote add heroku https://heroku:${{ secrets.HEROKU_API_KEY }}@git.heroku.com/${{ secrets.HEROKU_APP_NAME }}.git

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,9 @@ concurrency:
 jobs:
   prod_robot_tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     environment: production
     steps:
       - name: Checkout code
@@ -73,6 +76,12 @@ jobs:
 
       - name: Wait for deploy to be applied
         run: sleep 3
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_COGNITO_CLEANUP_ASSUME_ROLE }}
+          aws-region: ${{ vars.VITE_AWS_REGION }}
 
       - name: Run Cognito cleanup
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,6 +2,9 @@ name: Deploy and robot tests in production
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - rc-*
 
 concurrency:
   group: uses-test-cognito-users

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,10 @@ name: Deploy and robot tests
 on:
   workflow_dispatch:
 
+concurrency:
+  group: uses-test-cognito-users
+  cancel-in-progress: false
+
 jobs:
   prod_robot_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,12 +35,16 @@ jobs:
           SURGE_DEPLOY_TOKEN: ${{ secrets.SURGE_DEPLOY_TOKEN }}
         run: surge ./apps/mobile-ui/dist --domain http://diory-mobile-proto.surge.sh --token $SURGE_DEPLOY_TOKEN
 
-      # - name: Deploy to Heroku
-      #   env:
-      #     HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-      #   run: |
-      #     git remote add heroku https://git.heroku.com/${{ secrets.HEROKU_APP_NAME }}.git
-      #     git subtree push --prefix apps/mobile-server heroku main --force
+      - name: Install Heroku CLI
+        run: |
+          curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Deploy to Heroku
+        env:
+          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
+        run: |
+          heroku git:remote -a ${{ secrets.HEROKU_APP_NAME }}
+          git subtree push --prefix apps/mobile-server heroku main
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,10 @@
 name: Lint & test
 
-on: [push]
+on:
+  push:
+    branches:
+      - "*"
+      - "!rc-*"
 
 jobs:
   local_lint_test:

--- a/.github/workflows/robot-test-local.yml
+++ b/.github/workflows/robot-test-local.yml
@@ -2,6 +2,10 @@ name: Robot test
 
 on: [push]
 
+concurrency:
+  group: uses-test-cognito-users
+  cancel-in-progress: false
+
 jobs:
   local_robot_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/robot-test-local.yml
+++ b/.github/workflows/robot-test-local.yml
@@ -1,6 +1,10 @@
 name: Robot test
 
-on: [push]
+on:
+  push:
+    branches:
+      - "*"
+      - "!rc-*"
 
 concurrency:
   group: uses-test-cognito-users

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Mobile proto
 
+## Deploy
+
+1. Prepare Heroku-compatible version in own branch (e.g. remove jwkToPem.default)
+2. Run Deploy workflow in Github Action
+
 ## Infra
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,12 +1,5 @@
 # Mobile proto
 
-## Server
-
-```
-heroku git:remote -a mobile-proto-server
-git subtree push --prefix apps/mobile-server heroku main
-```
-
 ## Infra
 
 ```

--- a/apps/mobile-server/README.md
+++ b/apps/mobile-server/README.md
@@ -27,3 +27,30 @@ http://localhost:3000/room/content?cid=bafkreifhhmoftoo26lc223k5riwflm6uvgrizwak
 Thumbnail:
 
 http://localhost:3000/room/thumbnail?dioryId=5456c2c3-4a69-4d80-bd2f-caa9945cff71
+
+## Server deploy
+
+```
+# Deploying a subtree to Heroku doesn't work this simple...
+heroku git:remote -a mobile-proto-server
+git subtree push --prefix apps/mobile-server heroku main
+```
+
+Gives error:
+
+```
+$ git subtree push --prefix apps/mobile-server heroku main
+git push using:  heroku main
+To https://git.heroku.com/***.git
+ ! [rejected]        1f8688cd13a886c624cbe24b7e9994eaa7f49336 -> main (non-fast-forward)
+error: failed to push some refs to 'https://git.heroku.com/***.git'
+```
+
+Solution
+
+```
+git subtree split --prefix apps/mobile-server -b heroku-deploy
+git checkout heroku-deploy
+git cherry-pick 020b4a1
+git push heroku heroku-deploy:main --force
+```

--- a/apps/mobile-ui/src/loginPage.tsx
+++ b/apps/mobile-ui/src/loginPage.tsx
@@ -90,9 +90,15 @@ const LoginPage = () => {
             />
           </div>
         )}
-        <button data-test-id="signInOrUpSubmit" type="submit">
-          {isSignUp ? "Sign Up" : "Sign In"}
-        </button>
+        {isSignUp ? (
+          <button data-test-id="signUpSubmit" type="submit">
+            Sign up
+          </button>
+        ) : (
+          <button data-test-id="signInSubmit" type="submit">
+            Sign In
+          </button>
+        )}
       </form>
       <button
         data-test-id="signInOrUpToggle"

--- a/tests/main.robot
+++ b/tests/main.robot
@@ -9,7 +9,8 @@ ${EXISTING_EMAIL}    %{EXISTING_EMAIL}
 ${PASSWORD}     Password1234%
 
 *** Test Cases ***
-Test Login and Verify Alert
+User with wrong password: "Incorrect username or password" error
+# uses already existing user's email with wrong password
     New Browser  headless=True
     New Page  ${BASE_URL}
     Fill Text    id=email    ${EXISTING_EMAIL}
@@ -19,7 +20,8 @@ Test Login and Verify Alert
     Should Be Equal    ${error_text}    Sign in failed: NotAuthorizedException: Incorrect username or password.
     Close Browser
 
-Sign up, login, verify room selection and root diory
+Complete sign up and login flow for new user: checks demo & native rooms
+# uses email which gets auto-confirmed
     New Browser  headless=True
     New Page  ${BASE_URL}
     Click    css=button[data-test-id="signInOrUpToggle"]
@@ -43,7 +45,8 @@ Sign up, login, verify room selection and root diory
     Close Browser
 
 
-Test Sign up and User Not Confirmed
+Sign up and login flow for non-confirmed user: "User is not confirmed" error
+# uses email which doesn't get auto-confirmed, needs to be confirmed manually
     New Browser  headless=True
     New Page  ${BASE_URL}
     Click    css=button[data-test-id="signInOrUpToggle"]
@@ -51,7 +54,8 @@ Test Sign up and User Not Confirmed
     Fill Text    id=password    ${PASSWORD}
     Fill Text    id=confirmPassword    ${PASSWORD}
     Click    css=button[data-test-id="signInOrUpSubmit"]
-    Sleep  1
+    # To prevent flakiness as signup button doesn't always to sign in button and gets clicked twice
+    Sleep  2
     Click    css=button[data-test-id="signInOrUpSubmit"]
     ${error_text}=    Get Text    data-test-id=errorMessage
     Should Be Equal    ${error_text}    Sign in failed: UserNotConfirmedException: User is not confirmed.

--- a/tests/main.robot
+++ b/tests/main.robot
@@ -15,7 +15,7 @@ User with wrong password: "Incorrect username or password" error
     New Page  ${BASE_URL}
     Fill Text    id=email    ${EXISTING_EMAIL}
     Fill Text    id=password    ${PASSWORD}
-    Click    css=button[data-test-id="signInOrUpSubmit"]
+    Click    css=button[data-test-id="signInSubmit"]
     ${error_text}=    Get Text    data-test-id=errorMessage
     Should Be Equal    ${error_text}    Sign in failed: NotAuthorizedException: Incorrect username or password.
     Close Browser
@@ -28,10 +28,8 @@ Complete sign up and login flow for new user: checks demo & native rooms
     Fill Text    id=email    ${AUTO_USER_EMAIL}
     Fill Text    id=password    ${PASSWORD}
     Fill Text    id=confirmPassword    ${PASSWORD}
-    Click    css=button[data-test-id="signInOrUpSubmit"]
-    Sleep  1
-    Click    css=button[data-test-id="signInOrUpSubmit"]
-    Sleep  1
+    Click    css=button[data-test-id="signUpSubmit"]
+    Click    css=button[data-test-id="signInSubmit"]
     ${demo_item}=    Get Text    data-test-id=room-selection-item-demo
     Should Be Equal    ${demo_item}    DEMO
     ${native_item}=    Get Text    data-test-id=room-selection-item-native
@@ -53,10 +51,10 @@ Sign up and login flow for non-confirmed user: "User is not confirmed" error
     Fill Text    id=email    ${NON_CONFIRMED_EMAIL}
     Fill Text    id=password    ${PASSWORD}
     Fill Text    id=confirmPassword    ${PASSWORD}
-    Click    css=button[data-test-id="signInOrUpSubmit"]
+    Click    css=button[data-test-id="signUpSubmit"]
     # To prevent flakiness as signup button doesn't always to sign in button and gets clicked twice
-    Sleep  2
-    Click    css=button[data-test-id="signInOrUpSubmit"]
+    # Sleep  2
+    Click    css=button[data-test-id="signInSubmit"]
     ${error_text}=    Get Text    data-test-id=errorMessage
     Should Be Equal    ${error_text}    Sign in failed: UserNotConfirmedException: User is not confirmed.
     Close Browser


### PR DESCRIPTION
- ugly way to deploy to Heroku in CI
  - requires also modifying `jwkToPem.default` -> `jwkToPem`
- fix flaky test
- prevent running concurrently Cognito test user related workflows

Two issues:
- [ ] Deploying Node app to Heroku doesn't work with monorepo (subtree)
- [ ] Default imports work differently in Heroku than in local: builds break either in local or in Heroku
```
-    return jwt.verify(token, jwkToPem(publicKey), {
+    return jwt.verify(token, jwkToPem.default(publicKey), {
```